### PR TITLE
create acme challenges directory if it doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- create the acme challenges folder if it doesn't exist.
+
 ### Changed
 ### Removed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,17 @@
   become_user: "{{ letsencrypt_webuser }}"
   tags: ['letsencrypt', 'letsencrypt:configuration']
 
+- name: "Create acme challenges custom folder"
+  file:
+    state: directory
+    path: "{{ letsencrypt_alternative_acme_folder }}/"
+    owner: "{{ letsencrypt_webuser }}"
+    group: "{{ letsencrypt_webuser }}"
+  become: true
+  become_user: "{{ letsencrypt_webuser }}"
+  tags: ['letsencrypt', 'letsencrypt:configuration']
+
+
 # depending on the order that letsencrypt and nginx roles get run
 # on an initial deploy, there is a way that `/var/www` can end up
 # with restrictive permissions that prevent nginx from getting


### PR DESCRIPTION
On a fresh Tahoe deploy that doesn't have the gcs-fuse mounted bucket populated yet, it will mount `/var/www/letsencrypt` but there won't be an `acme-challenges-custom-folder` yet and certbot will fail with

```
Hook command "/opt/scripts/authenticator.sh" returned error code 1
Error output from authenticator.sh:
/opt/scripts/authenticator.sh: line 2: /var/www/letsencrypt/acme-challenges-custom-folder/...: No such file or directory
```

(it's fine on existing deployments or ones where we've copied the contents of the storage bucket over)